### PR TITLE
Add an abstraction over file paths with arkdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.npy
+arkdir.json
 
 
 # Byte-compiled / optimized / DLL files

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,4 @@ test:
 .PHONY: type
 type:
 				python -m mypy methods
+				python -m mypy arkdir

--- a/arkdir/__init__.py
+++ b/arkdir/__init__.py
@@ -1,0 +1,41 @@
+# File path resolution across space and time.
+# Something like DNS might work well here, maybe. The idea being there
+# should be no hardcoded paths to files or data anywhere making it portable
+# to a distributed pipeline or similar. If you want to save something you ask
+# for a path and give a local, programming-level name to this object. For now,
+# this is crudely done via JSON mappings that can be merged a abstracted upon
+# later.
+import os
+import json
+from typing import Dict
+
+# This is not efficient, or concurrent-safe... but it'll do.
+class Arkpath:
+    base_dir = os.getenv("ARKDIR", default=os.getcwd())
+    paths: Dict[str, str] = {}
+
+    def _refresh(self):
+        path = os.path.join(self.base_dir, "arkdir.json")
+        if os.path.exists(path):
+            with open(path, "r") as fp:
+                self.paths = json.load(fp)
+
+    def save(self, name: str) -> str:
+        self._refresh()
+        path = os.path.join(self.base_dir, name)
+        self.paths[name] = path
+        with open(os.path.join(self.base_dir, "arkdir.json"), "w") as fp:
+            json.dump(self.paths,fp)
+        return path
+
+    def load(self, name: str) -> str:
+        maybe = self.paths.get(name)
+        if maybe is None:
+            self._refresh()
+            maybe = self.paths.get(name)
+            if maybe is None:
+                raise NameError(name)
+            else:
+                return maybe
+        else:
+            return maybe

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 
 from methods import permanence
+import arkdir
 
 parser = argparse.ArgumentParser(description="TMF Methodology Implementation.")
 
@@ -20,22 +21,22 @@ args = vars(parser.parse_args())
 method = str(args['method']).lower()
 
 # Where to save outputs, we could probably do better.
-ark_dir = os.getenv("ARKDIR", default=os.getcwd())
+arkpath = arkdir.Arkpath()
 
 if method == "permanence":
-    add_path = os.path.join(ark_dir, "add.npy")
-    leak_path = os.path.join(ark_dir, "leak.npy")
+    add_path = arkpath.load("add.npy")
+    leak_path = arkpath.load("leak.npy")
     additionality = np.load(add_path)
     leakage = np.load(leak_path)
     c = permanence.net_sequestration(additionality, leakage, 1)
     print(c)
 elif method == "additionality":
     additionality = np.array([ 1.0, 1.1 ])
-    path = os.path.join(ark_dir, "add")
+    path = arkpath.save("add.npy")
     np.save(path, additionality)
 elif method == "leakage":
     leakage = np.array([ 0.5, 0.6 ])
-    path = os.path.join(ark_dir, "leak")
+    path = arkpath.save("leak.npy")
     np.save(path, leakage)
 else:
     print(f'Unknown methodology {method}')


### PR DESCRIPTION
The idea is the pipeline can merge and modify `arkdir.json` files and update the runc config accordingly, a DNS-like service might be cool here à la https://docs.ipfs.tech/concepts/ipns/