### PR TITLE
Print stacktrace on value errors

### DIFF
--- a/methods/inputs/download_accessibility.py
+++ b/methods/inputs/download_accessibility.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import traceback
 from shutil import move
 from glob import glob
 
@@ -62,6 +63,7 @@ def main() -> None:
         sys.exit(1)
     except ValueError as exc:
         print(f"Invalid value: {exc.args}", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/methods/inputs/generate_matching_area.py
+++ b/methods/inputs/generate_matching_area.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import sys
+import traceback
 
 import shapely # type: ignore
 from fiona.errors import DriverError # type: ignore
@@ -101,6 +102,7 @@ def main() -> None:
         sys.exit(1)
     except ValueError as exc:
         print(f"Bad value: {exc.args[0]}", file=sys.stderr)
+        print(traceback.format_exc(), file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Value errors may also be coming from libraries we are using -- I'm currently experiencing this in the pipeline when using the `generate_matching_area` script with project 1047:

```
2023-07-23 08:26.13: Bad value: Sequences of multi-polygons are not valid arguments
```

That's all we get out so it might be useful to then print the stack trace. Other errors like file not found probably don't need this.