### PR TITLE
Change how we use pandas to get better performance.

### DIFF
--- a/methods/matching/find_pairs.py
+++ b/methods/matching/find_pairs.py
@@ -82,19 +82,20 @@ def find_match_iteration(
             "cpc10_u", "cpc10_d"
         ]
         k_soft =  np.array(k_row[distance_columns].to_list())
-        just_cols = filtered_s[distance_columns]
+        just_cols = filtered_s[distance_columns].to_numpy()
 
         min_distance = 10000000000.0
         min_index = None
-        for s_tup in just_cols.itertuples():
-            distance = mahalanobis(k_soft, list(s_tup[1:]), invconv)
+        for index in range(len(just_cols)): # pylint: disable=C0200
+            s_row = just_cols[index]
+            distance = mahalanobis(k_soft, s_row, invconv)
             if distance < min_distance:
                 min_distance = distance
-                min_index = s_tup.Index
+                min_index = index
         if min_index is None:
             logging.warning("We got no minimum despite having %d potential matches", len(filtered_s))
             continue
-        match = filtered_s.loc[min_index]
+        match = filtered_s.iloc[min_index]
 
         results.append([
             k_row.lat,


### PR DESCRIPTION
I did some profiling and reading up on pandas performance, and got the speed for this stage down to about 10% of the original.

The main issue, flagged by the profiler, is that accessing the columns on a row is expensive, with most of the time being spent in Python's "get_attr" method. Moving to having columns already filtered and then just selecting the row and calling tolist() on the row gave us most of the performance win.

The secondary issue is that panda's apply method internally is doing the same as iterrows, and threads on the internet indicated that itertuples() is generally faster, and that gave us another boost in performance. Apparently taking the data out of pandas entirely and using numpy directly would be another option, but for now I felt getting it down to 10% was good enough to be getting on with, given that the code is still relatively readable.