### PR TITLE
Make geometry expansion faster for complex geometry

### DIFF
--- a/methods/common/geometry.py
+++ b/methods/common/geometry.py
@@ -13,7 +13,7 @@ def utm_for_geometry(lat: float, lng: float) -> int:
         epsg_code = 32600 + utm_band
     return epsg_code
 
-def expand_recurse_geoms(shape: shapely.Geometry, radius: float):
+def expand_recurse_geoms(shape: shapely.Geometry, radius: float) -> shapely.Geometry:
     # Calling .buffer directly on a shape is incredibly slow when it contains lots of geometry.
     # So we call it on each piece of geometry instead. No reason that should be faster, but it is
     if hasattr(shape, 'geoms'):


### PR DESCRIPTION
No cleverness here; for whatever reason, expanding each bit of geometry and merging is faster than just calling expand