### PR TITLE
Use branch of biomass-recovery that lets you specify LOG_PATH for log directory creation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ scipy
 numba
 matplotlib
 geojson
-git+https://github.com/quantifyearth/yirgacheffe@bd2e91c773a414f66340ebb8c13044a1b1a6045f
-git+https://github.com/carboncredits/biomass-recovery@170630d50e42083c545643928747d67aa7245291
+git+https://github.com/quantifyearth/yirgacheffe@743d26520c6438bd6e1f08e7822a54f965723405
+git+https://github.com/quantifyearth/biomass-recovery@9e54f80832a7eca915ebd13b03df9db2a08aee9d
 
 # developement
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ scipy
 numba
 matplotlib
 geojson
-git+https://github.com/quantifyearth/yirgacheffe@743d26520c6438bd6e1f08e7822a54f965723405
-git+https://github.com/quantifyearth/biomass-recovery@9e54f80832a7eca915ebd13b03df9db2a08aee9d
+git+https://github.com/quantifyearth/yirgacheffe@bd2e91c773a414f66340ebb8c13044a1b1a6045f
+git+https://github.com/carboncredits/biomass-recovery@9e54f80832a7eca915ebd13b03df9db2a08aee9d
 
 # developement
 mypy


### PR DESCRIPTION
This update means you can control where the biomass-recovery package creates its logging directory. Without this it'll be placed in /usr/lib...site-packages in the docker image, which will fail if you mount the rootfs as read only.

This is in a PR made to the upstream repo for that module, just we don't know when that'll be merged. https://github.com/ameliaholcomb/biomass-recovery/pull/15

This now also pulls in a fix to yirgacheffe for an issue Abby hit with a layer that hand empty features in, which yirgacheffe handled ungracefully.