### PR TITLE
Install littlejohn in the docker image for manual running via fsark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
+FROM golang:bullseye AS littlejohn
+RUN git clone https://github.com/carboncredits/littlejohn.git
+WORKDIR littlejohn
+RUN go build
+
 FROM ghcr.io/osgeo/gdal:ubuntu-small-3.6.4
+
+COPY --from=littlejohn /go/littlejohn/littlejohn /bin/littlejohn
 
 RUN apt-get update -qqy && \
 apt-get install -qy \


### PR DESCRIPTION
Just adds littlejohn to the Dockerfile, which allows people to do multiple projects in a container locally.