### PR TITLE
Speed up find_pairs by using a Numba-optimised kd-tree for searching M to build S

### DIFF
--- a/methods/utils/kd_tree.py
+++ b/methods/utils/kd_tree.py
@@ -1,0 +1,354 @@
+import math
+
+import numpy as np
+from numba import float32, int32 # type: ignore
+from numba.experimental import jitclass # type: ignore
+
+
+class KDTree:
+    def __init__(self):
+        pass
+
+    def contains(self, _range) -> bool:
+        raise NotImplementedError()
+
+    def depth(self) -> int:
+        return 1
+
+    def size(self) -> int:
+        return 1
+
+    def count(self) -> int:
+        return 0
+
+    def members(self, _range) -> np.ndarray:
+        raise NotImplementedError()
+
+    def dump(self, _space: str):
+        raise NotImplementedError()
+
+class KDLeaf(KDTree):
+    def __init__(self, point, index):
+        self.point = point
+        self.index = index
+    def contains(self, range) -> bool:
+        return np.all(range[0] <= self.point) & np.all(range[1] >= self.point) # type: ignore
+    def members(self, range):
+        if self.contains(range):
+            return np.array([self.index])
+        return np.empty(0, dtype=np.int_)
+    def dump(self, space: str):
+        print(space, f"point {self.point}")
+    def count(self):
+        return 1
+
+class KDList(KDTree):
+    def __init__(self, points, indexes):
+        self.points = points
+        self.indexes = indexes
+    def contains(self, range) -> bool:
+        return np.any(np.all(range[0] <= self.points, axis=1) & np.all(range[1] >= self.points, axis=1)) # type: ignore
+    def members(self, range):
+        return self.indexes[np.all(range[0] <= self.points, axis=1) & np.all(range[1] >= self.points, axis=1)]
+    def dump(self, space: str):
+        print(space, f"points {self.points}")
+    def count(self):
+        return len(self.points)
+
+class KDSplit(KDTree):
+    def __init__(self, d: int, value: float, left: KDTree, right: KDTree):
+        self.d = d
+        self.value = value
+        self.left = left
+        self.right = right
+    def contains(self, range) -> bool:
+        l = self.value - range[0, self.d] # Amount on left side
+        r = range[1, self.d] - self.value # Amount on right side
+        # Either l or r must be positive, or both
+        # Pick the biggest first
+        if l >= r:
+            if self.left.contains(range):
+                return True
+            # Visit the rest if it is inside
+            if r >= 0:
+                if self.right.contains(range):
+                    return True
+        else:
+            if self.right.contains(range):
+                return True
+            # Visit the rest if it is inside
+            if l >= 0:
+                if self.left.contains(range):
+                    return True
+        return False
+
+    def members(self, range):
+        result = None
+        if self.value >= range[0, self.d]:
+            result = self.left.members(range)
+        if range[1, self.d] >= self.value:
+            rights = self.right.members(range)
+            if result is None:
+                result = rights
+            else:
+                result = np.append(result, rights, axis=0)
+        return result if result is not None else np.empty(0, dtype=np.int_)
+
+    def size(self) -> int:
+        return 1 + self.left.size() + self.right.size()
+
+    def depth(self) -> int:
+        return 1 + max(self.left.depth(), self.right.depth())
+
+    def dump(self, space: str):
+        print(space, f"split d{self.d} at {self.value}")
+        print(space + "  <")
+        self.left.dump(space + "\t")
+        print(space + "  >")
+        self.right.dump(space + "\t")
+    def count(self):
+        return self.left.count() + self.right.count()
+
+
+class KDRangeTree:
+    def __init__(self, tree, widths):
+        self.tree = tree
+        self.widths = widths
+    def contains(self, point) -> bool:
+        return self.tree.contains(np.array([point - self.widths, point + self.widths]))
+    def members(self, point) -> np.ndarray:
+        return self.tree.members(np.array([point - self.widths, point + self.widths]))
+    def dump(self, space: str):
+        self.tree.dump(space)
+    def size(self):
+        return self.tree.size()
+    def depth(self):
+        return self.tree.depth()
+    def count(self):
+        return self.tree.count()
+
+def make_kdrangetree(points, widths):
+    def make_kdtree_internal(points, indexes):
+        if len(points) == 1:
+            return KDLeaf(points[0], indexes[0])
+        if len(points) < 30:
+            return KDList(points, indexes)
+        # Find split in dimension with most bins
+        dimensions = points.shape[1]
+        bins: float = None # type: ignore
+        chosen_d_min = 0
+        chosen_d_max = 0
+        chosen_d = 0
+        for d in range(dimensions):
+            d_max = np.max(points[:, d])
+            d_min = np.min(points[:, d])
+            d_range = d_max - d_min
+            d_bins = d_range / widths[d]
+            if bins is None or d_bins > bins:
+                bins = d_bins
+                chosen_d = d
+                chosen_d_max = d_max
+                chosen_d_min = d_min
+
+        if bins < 1.3:
+            print(bins)
+            print(chosen_d, chosen_d_min, chosen_d_max)
+            # No split is very worthwhile, so dump points
+            return KDList(points, indexes)
+
+        split_at = np.median(points[:, chosen_d])
+        # Avoid degenerate cases
+        if split_at == chosen_d_max or split_at == chosen_d_min:
+            split_at = (chosen_d_max + chosen_d_min) / 2
+
+        left_side = points[:, chosen_d] <= split_at
+        right_side = ~left_side
+        lefts = points[left_side]
+        rights = points[right_side]
+        lefts_indexes = indexes[left_side]
+        rights_indexes = indexes[right_side]
+        return KDSplit(chosen_d, split_at, make_kdtree_internal(lefts, lefts_indexes), make_kdtree_internal(rights, rights_indexes))
+    indexes = np.arange(len(points))
+    return KDRangeTree(make_kdtree_internal(points, indexes), widths)
+
+@jitclass([('ds', int32[:]),  ('values', float32[:]), ('items', int32[:]), ('lefts', int32[:]), ('rights', int32[:]), ('rows', float32[:, :]), ('dimensions', int32), ('widths', float32[:])])
+class RumbaTree:
+    def __init__(self, ds: np.ndarray, values: np.ndarray, items: np.ndarray, lefts: np.ndarray, rights: np.ndarray, rows: np.ndarray, dimensions: int, widths: np.ndarray):
+        self.ds = ds
+        self.values = values
+        self.items = items
+        self.lefts = lefts
+        self.rights = rights
+        self.rows = rows
+        self.dimensions = dimensions
+        self.widths = widths
+    def members(self, point: np.ndarray):
+        low = point - self.widths
+        high = point + self.widths
+        queue = [0]
+        finds = []
+        while len(queue) > 0:
+            pos = queue.pop()
+            d = self.ds[pos]
+            value = self.values[pos]
+            if math.isnan(value):
+                i = d
+                item = self.items[i]
+                while item != -1:
+                    # Check item
+                    found = True
+                    for d in range(self.dimensions):
+                        value = self.rows[item, d]
+                        if value < low[d]:
+                            found = False
+                            break
+                        if value > high[d]:
+                            found = False
+                            break
+                    if found:
+                        finds.append(item)
+                    i += 1
+                    item = self.items[i]
+            else:
+                if value <= high[d]:
+                    queue.append(self.rights[pos])
+                if value >= low[d]:
+                    queue.append(self.lefts[pos])
+        return finds
+    def count_members(self, point: np.ndarray):
+        low = point - self.widths
+        high = point + self.widths
+        queue = [0]
+        count = 0
+        while len(queue) > 0:
+            pos = queue.pop()
+            d = self.ds[pos]
+            value = self.values[pos]
+            if math.isnan(value):
+                i = d
+                item = self.items[i]
+                while item != -1:
+                    # Check item
+                    found = True
+                    for d in range(self.dimensions):
+                        value = self.rows[item, d]
+                        if value < low[d]:
+                            found = False
+                            break
+                        if value > high[d]:
+                            found = False
+                            break
+                    if found:
+                        count += 1
+                    i += 1
+                    item = self.items[i]
+            else:
+                if value <= high[d]:
+                    queue.append(self.rights[pos])
+                if value >= low[d]:
+                    queue.append(self.lefts[pos])
+        return count
+    def members_sample(self, point: np.ndarray, count: int, rng: np.random.Generator):
+        low = point - self.widths
+        high = point + self.widths
+        queue = [0]
+        finds: list[int] = []
+        found_count = 0
+        rand_state = rng.integers(0, 0xFFFF_FFFF_FFFF_FFFF, 4, np.uint64, True)
+        while len(queue) > 0:
+            pos = queue.pop()
+            d = self.ds[pos]
+            value = self.values[pos]
+            if math.isnan(value):
+                i = d
+                item: int = self.items[i] # type: ignore
+                while item != -1:
+                    # Check item
+                    found = True
+                    for d in range(self.dimensions):
+                        value = self.rows[item, d]
+                        if value < low[d]:
+                            found = False
+                            break
+                        if value > high[d]:
+                            found = False
+                            break
+                    if found:
+                        found_count += 1
+                        if len(finds) < count:
+                            finds.append(item)
+                        else:
+                            # Replace a random item in finds based on on-line search probability
+                            # Source: https://prng.di.unimi.it/xoshiro256plus.c
+                            rand = rand_state[0] + rand_state[3]
+                            t = rand_state[1] << 17
+                            rand_state[2] ^= rand_state[0]
+                            rand_state[3] ^= rand_state[1]
+                            rand_state[1] ^= rand_state[2]
+                            rand_state[0] ^= rand_state[3]
+                            rand_state[2] ^= t
+                            rand_state[3] = (rand_state[3] >> 45) | (rand_state[3] << 19)
+                            
+                            pos = rand % found_count
+
+                            if pos < count:
+                                finds[pos] = item
+                    i += 1
+                    item = self.items[i] # type: ignore
+            else:
+                if value <= high[d]:
+                    queue.append(self.rights[pos])
+                if value >= low[d]:
+                    queue.append(self.lefts[pos])
+        return finds
+
+NAN = float('nan')
+def make_rumba_tree(tree: KDRangeTree, rows: np.ndarray):
+    ds: list[int] = []
+    values = []
+    items: list[int] = []
+    lefts = []
+    rights = []
+    widths = None
+    def recurse(node):
+        nonlocal widths
+        if isinstance(node, KDSplit):
+            pos = len(ds)
+            ds.append(node.d)
+            values.append(node.value)
+            lefts.append(pos + 1) # Next node we output will be left
+            rights.append(0xDEADBEEF) # Put placeholder here...
+            recurse(node.left)
+            rights[pos] = len(ds) # ..and fixup right to be the next node we output
+            recurse(node.right)
+        elif isinstance(node, KDList):
+            values.append(NAN)
+            ds.append(len(items))
+            lefts.append(-1) # Specific invalid values for debugging an errors in tree build
+            rights.append(-2)
+            for item in node.indexes:
+                items.append(item)
+            items.append(-1)
+        elif isinstance(node, KDLeaf):
+            values.append(NAN)
+            ds.append(len(items))
+            lefts.append(-3)
+            rights.append(-4)
+            items.append(node.index)
+            items.append(-1)
+        elif isinstance(node, KDRangeTree):
+            widths = node.widths
+            recurse(node.tree)
+    recurse(tree)
+    if widths is None:
+        raise ValueError(f"Expected KDRangeTree, got {tree}")
+    return RumbaTree(
+        np.array(ds, dtype=np.int32),
+        np.array(values, dtype=np.float32),
+        np.array(items, dtype=np.int32),
+        np.array(lefts, dtype=np.int32),
+        np.array(rights, dtype=np.int32),
+        np.ascontiguousarray(rows, dtype=np.float32),
+        rows.shape[1],
+        np.ascontiguousarray(widths, dtype=np.float32),
+    )

--- a/test/test_find_pairs.py
+++ b/test/test_find_pairs.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.spatial.distance import mahalanobis
+import pandas as pd
 
 from methods.matching import find_pairs
 
@@ -54,16 +55,28 @@ def test_make_s_set_mask():
         [0.5, 0.6],
     ], dtype=np.float32)
 
-    starting_positions = np.array([1, 2, 3, 4])
+    rng = np.random.default_rng(42)
+    k_set = np.array([k_dist_hard, k_dist_thresholded])
+    k_set = np.moveaxis(k_set, 0, 1).reshape(-1, k_dist_hard.shape[1] + k_dist_thresholded.shape[1])
+    k_set = pd.DataFrame(k_set)
+
+    m_set = np.array([m_dist_hard, m_dist_thresholded])
+    m_set = np.moveaxis(m_set, 0, 1).reshape(-1, m_dist_hard.shape[1] + m_dist_thresholded.shape[1])
+    m_set = pd.DataFrame(m_set)
+
+    hard_match_columns = list(range(k_dist_hard.shape[1]))
+    hard_match_categories = {k.tobytes(): k for k in k_dist_hard}
 
     # calculate using make_s_set_mask
     s_subset_mask, misses = find_pairs.make_s_set_mask(
+        rng,
+        k_set,
+        m_set,
         m_dist_thresholded,
         k_dist_thresholded,
-        m_dist_hard,
-        k_dist_hard,
-        starting_positions,
+        hard_match_columns,
         2,
+        hard_match_categories,
     )
 
     assert (s_subset_mask == [True, False, False, False, False]).all()

--- a/test/test_kd_tree.py
+++ b/test/test_kd_tree.py
@@ -1,0 +1,176 @@
+import math
+from time import time
+import numpy as np
+import pandas as pd
+
+from methods.common.luc import luc_matching_columns
+from methods.utils.kd_tree import KDRangeTree, make_kdrangetree, make_rumba_tree
+
+ALLOWED_VARIATION = np.array([
+    200,
+    2.5,
+    10,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+    0.1,
+])
+
+def test_kd_tree_matches_as_expected():
+    def build_rects(items):
+        rects = []
+        for item in items:
+            lefts = []
+            rights = []
+            for dimension, value in enumerate(item):
+                width = ALLOWED_VARIATION[dimension]
+                if width < 0:
+                    fraction = -width
+                    width = value * fraction
+                lefts.append(value - width)
+                rights.append(value + width)
+            rects.append([lefts, rights])
+        return np.array(rects)
+
+    expected_fraction = 1 / 100 # This proportion of pixels we end up matching
+
+    def build_kdranged_tree_for_k(k_rows) -> KDRangeTree:
+        return make_kdrangetree(np.array([(
+                row.elevation,
+                row.slope,
+                row.access,
+                row["cpc0_u"],
+                row["cpc0_d"],
+                row["cpc5_u"],
+                row["cpc5_d"],
+                row["cpc10_u"],
+                row["cpc10_d"],
+                ) for row in k_rows
+            ]), ALLOWED_VARIATION)
+
+
+    luc0, luc5, luc10 = luc_matching_columns(2012)
+    source_pixels = pd.read_parquet("./test/data/1201-k.parquet")
+
+    # Split source_pixels into classes
+    source_rows = []
+    for _, row in source_pixels.iterrows():
+        key = (int(row.ecoregion) << 16) | (int(row[luc0]) << 10) | (int(row[luc5]) << 5) | (int(row[luc10]))
+        if key != 1967137:
+            continue
+        source_rows.append(row)
+
+    source = np.array([
+        [
+            row.elevation,
+            row.slope,
+            row.access,
+            row["cpc0_u"],
+            row["cpc0_d"],
+            row["cpc5_u"],
+            row["cpc5_d"],
+            row["cpc10_u"],
+            row["cpc10_d"],
+        ] for row in source_rows
+    ])
+
+    # Invent an array of values that matches the expected_fraction
+    length = 10000
+    np.random.seed(42)
+
+    ranges = np.transpose(np.array([
+        np.min(source, axis=0),
+        np.max(source, axis=0)
+    ]))
+
+    # Safe ranges (exclude 10% of outliers)
+    safe_ranges = np.transpose(np.array([
+        np.quantile(source, 0.05, axis=0),
+        np.quantile(source, 0.95, axis=0)
+    ]))
+
+    # Need to put an estimate here of how much of the area inside those 90% bounds is actually filled
+    filled_fraction = 0.775
+
+    # Proportion of values that should fall inside each dimension
+    inside_fraction = expected_fraction * math.pow(1 / filled_fraction, len(ranges))
+    inside_length = math.ceil(length * inside_fraction)
+    inside_values = np.random.uniform(safe_ranges[:, 0], safe_ranges[:, 1], (inside_length, len(ranges)))
+
+    widths = ranges[:, 1] - ranges[:, 0]
+    range_extension = 100 * widths # Width extension makes it very unlikely a random value will be inside
+    outside_ranges = np.transpose([ranges[:, 0] - range_extension, ranges[:, 1] + range_extension])
+
+    outside_length = length - inside_length
+    outside_values = np.random.uniform(outside_ranges[:, 0], outside_ranges[:, 1], (outside_length, len(ranges)))
+
+    test_values = np.append(inside_values, outside_values, axis=0)
+
+    def do_np_matching():
+        source_rects = build_rects(source)
+        found = 0
+        for i in range(length):
+            pos = np.all((test_values[i] >= source_rects[:, 0]) & (test_values[i] <= source_rects[:, 1]), axis=1)
+            found += 1 if np.any(pos) else 0
+        return found
+
+    def speed_of(what, func):
+        expected_finds = 946
+        start = time()
+        value = func()
+        end = time()
+        assert value == expected_finds, f"Got wrong value {value} for method {what}, expected {expected_finds}"
+        print(what, ": ", (end - start) / length, "per call")
+
+    print("making tree... (this will take a few seconds)")
+    start = time()
+    kd_tree = build_kdranged_tree_for_k(source_rows)
+    print("build time", time() - start)
+    print("tree depth", kd_tree.depth())
+    print("tree size", kd_tree.size())
+
+    def do_kdrange_tree_matching():
+        found = 0
+        for i in range(length):
+            found += 1 if len(kd_tree.members(test_values[i])) > 0 else 0
+        return found
+
+    rumba_tree = make_rumba_tree(kd_tree, source)
+
+    def do_rumba_tree_matching():
+        found = 0
+        for i in range(length):
+            found += 1 if len(rumba_tree.members(test_values[i])) > 0 else 0
+        return found
+
+    test_np_matching = False # This is slow but a useful check so I don't want to delete it
+    if test_np_matching:
+        speed_of("NP matching", do_np_matching)
+    speed_of("KD Tree matching", do_kdrange_tree_matching)
+    speed_of("Rumba matching", do_rumba_tree_matching)
+
+def test_rumba_tree_sampling():
+    """Check that the rumba tree members_sample function returns a uniform random sample.
+    
+    Actually only tests the mean converges to the middle index over a series of runs.
+    """
+    data = np.arange(3000).reshape((-1, 3))
+
+    # Build a tree
+    centre = np.array([1500, 1500, 1500])
+
+    kd_tree = make_kdrangetree(data, centre)
+    rumba_tree = make_rumba_tree(kd_tree, data)
+
+    assert 1000 == rumba_tree.count_members(centre)
+
+    means = []
+    for seed in range(100):
+        for i in range(100):
+            sample = rumba_tree.members_sample(centre, i + 1, np.random.default_rng(100 * seed + i))
+            means.append(np.mean(sample))
+    mean = np.mean(np.array(means))
+    mean_difference = abs(mean - 500)
+    assert mean_difference < 1


### PR DESCRIPTION
This has none of the memory sharing optimisations to make this easier to run in parallel (or possible for larger projects). It also has none of the optimisations we talked about to split M into 100 or so subsets and pick from the randomly.

However, it does seem to pick reasonable pairs and have better SMD number than the current version.

I'm happy to talk it through with anyone or do any further testing you want to suggest to make sure it is robust before I add the memory sharing optimisation (which requires a fair bit of restructuring to thread everything through but shouldn't change the output).