### PR TITLE
Remove reference to fiona, as it's dropped from geopandas 

### DIFF
--- a/methods/inputs/download_srtm_data.py
+++ b/methods/inputs/download_srtm_data.py
@@ -9,7 +9,6 @@ import logging
 
 import requests
 import shapely # type: ignore
-from fiona.errors import DriverError # type: ignore
 from geopandas import gpd # type: ignore
 
 from biomassrecovery.utils.unzip import unzip # type: ignore
@@ -127,16 +126,13 @@ def main() -> None:
                 "DESTINATION_ZIP_FOLDER DESTINATION_TIFF_FOLDER", file=sys.stderr)
             sys.exit(1)
 
-    try:
-        download_srtm_data(
-            project_boundaries_filename,
-            pixel_matching_boundaries_filename,
-            destination_zip_folder,
-            destination_tiff_folder
-        )
-    except DriverError as exc:
-        print(exc.args[0], file=sys.stderr)
-        sys.exit(1)
+    download_srtm_data(
+        project_boundaries_filename,
+        pixel_matching_boundaries_filename,
+        destination_zip_folder,
+        destination_tiff_folder
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/methods/inputs/generate_boundary.py
+++ b/methods/inputs/generate_boundary.py
@@ -1,7 +1,6 @@
 import argparse
 import sys
 
-from fiona.errors import DriverError # type: ignore
 from geopandas import gpd # type: ignore
 
 from methods.common.geometry import expand_boundaries
@@ -35,9 +34,6 @@ def main() -> None:
         generate_boundary(args.project_boundary_filename, args.output_filename)
     except FileNotFoundError as exc:
         print(f"Failed to find file {exc.filename}: {exc.strerror}", file=sys.stderr)
-        sys.exit(1)
-    except DriverError as exc:
-        print(exc.args[0], file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/methods/inputs/generate_leakage.py
+++ b/methods/inputs/generate_leakage.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 
 import shapely # type: ignore
-from fiona.errors import DriverError # type: ignore
 from geopandas import gpd # type: ignore
 
 from methods.common.geometry import expand_boundaries
@@ -42,9 +41,6 @@ def main() -> None:
         generate_leakage(args.project_boundary_filename, args.output_filename)
     except FileNotFoundError as exc:
         print(f"Failed to find file {exc.filename}: {exc.strerror}", file=sys.stderr)
-        sys.exit(1)
-    except DriverError as exc:
-        print(exc.args[0], file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/methods/inputs/generate_matching_area.py
+++ b/methods/inputs/generate_matching_area.py
@@ -6,7 +6,6 @@ import sys
 import traceback
 
 import shapely # type: ignore
-from fiona.errors import DriverError # type: ignore
 from geopandas import gpd # type: ignore
 
 from methods.common.geometry import expand_boundaries
@@ -145,9 +144,6 @@ def main() -> None:
         )
     except FileNotFoundError as exc:
         print(f"Failed to find file {exc.filename}: {exc.strerror}", file=sys.stderr)
-        sys.exit(1)
-    except DriverError as exc:
-        print(exc.args[0], file=sys.stderr)
         sys.exit(1)
     except ValueError as exc:
         print(f"Bad value: {exc.args[0]}", file=sys.stderr)

--- a/methods/inputs/simplify_ecoregions.py
+++ b/methods/inputs/simplify_ecoregions.py
@@ -8,7 +8,6 @@ import re
 import sys
 
 import shapely # type: ignore
-from fiona.errors import DriverError # type: ignore
 from geopandas import gpd # type: ignore
 from shapely.geometry import Polygon # type: ignore
 
@@ -73,11 +72,7 @@ def main() -> None:
         print(f"Usage: {sys.argv[0]} SOURCE_PATH TARGET_PATH JRC_TILES", file=sys.stderr)
         sys.exit(1)
 
-    try:
-        simplify_ecoregions(source_path, target_path, jrc_files_directory)
-    except DriverError as exc:
-        print(exc.args[0], file=sys.stderr)
-        sys.exit(1)
+    simplify_ecoregions(source_path, target_path, jrc_files_directory)
 
 if __name__ == "__main__":
     main()

--- a/methods/outputs/calculate_permanence.py
+++ b/methods/outputs/calculate_permanence.py
@@ -46,10 +46,10 @@ def net_sequestration(
     if year < minimum_year + 1 or year > maximum_year:
         raise ValueError(f"index for net sequesteration out of bounds: {year}")
 
-    additionality_t = additionality.loc[year][0]
-    leakage_t = leakage.loc[year][0]
-    additionality_t_prev = additionality.loc[year - 1][0]
-    leakage_t_prev = leakage.loc[year - 1][0]
+    additionality_t = float(additionality.loc[year][0])
+    leakage_t = float(leakage.loc[year][0])
+    additionality_t_prev = float(additionality.loc[year - 1][0])
+    leakage_t_prev = float(leakage.loc[year - 1][0])
 
     return (additionality_t - leakage_t) - (additionality_t_prev - leakage_t_prev)
 


### PR DESCRIPTION
In the most recent version of geopandas they removed Fiona as a dependancy. This was exposed before as file load errors in geopandas would result in a Fiona based exception, but now our attempts to catch those cause import errors, so I've removed them.