### PR TITLE
No longer need to pin numpy thanks to GDAL being better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN git clone https://github.com/carboncredits/littlejohn.git
 WORKDIR littlejohn
 RUN go build
 
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.4
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.10.1
 
 COPY --from=littlejohn /go/littlejohn/littlejohn /bin/littlejohn
 
@@ -18,9 +18,8 @@ apt-get install -qy \
 # You must install numpy before anything else otherwise
 # gdal's python bindings are sad. Pandas we full out as its slow
 # to build, and this means it'll be cached
-RUN pip install --upgrade pip
-RUN pip install numpy
-RUN pip install gdal[numpy]==3.8.4
+RUN pip config set global.break-system-packages true
+RUN pip install gdal[numpy]==3.10.1
 
 WORKDIR /usr/src/app
 COPY requirements.txt ./

--- a/methods/inputs/locate_gedi_data.py
+++ b/methods/inputs/locate_gedi_data.py
@@ -11,6 +11,9 @@ from biomassrecovery.data.gedi_download_pipeline import check_and_format_shape  
 from biomassrecovery.constants import GediProduct  # type: ignore
 from osgeo import ogr, osr  # type: ignore
 
+# you have to import gdal to get the type ogr.DataSource for mypy 🤦
+from osgeo import gdal # pylint: disable=W0611
+
 # load environment variables from .env file for Earthdata credentials
 dotenv.load_dotenv()
 EARTHDATA_USER = os.getenv("EARTHDATA_USER")

--- a/methods/utils/dranged_tree.py
+++ b/methods/utils/dranged_tree.py
@@ -17,17 +17,17 @@ import math
 
 class DRangedTree:
     def contains(self, point: np.ndarray):
-        raise NotImplemented
+        raise NotImplementedError
 
     def depth(self) -> int:
         return 1
-    
+
     def dump(self, space: str) -> None:
-        raise NotImplemented
-    
+        raise NotImplementedError
+
     def size(self) -> int:
         return 1
-    
+
     @staticmethod
     def build(items: np.ndarray, widths: np.ndarray, expected_fraction: float) -> DRangedTree:
         """
@@ -101,7 +101,7 @@ class FulfilledTree(DRangedTree):
         return 1 + self.subtree.depth()
     def size(self):
         return 1 + self.subtree.size()
-    
+
 class CheckTree(DRangedTree):
     def __init__(self, axis: int, value: float, subtree: DRangedTree, continuation: DRangedTree|None = None):
         self.axis = axis
@@ -198,10 +198,10 @@ class TreeState:
 
     def descend(self, j: int) -> TreeState:
         return TreeState(self, j)
-    
+
     def drop(self, j: int) -> TreeState:
         return TreeState(self, j, drop=True)
-    
+
     def print(self, s: str) -> None:
         if self.logging:
             print(self.depth * "  ", s)
@@ -247,7 +247,7 @@ def _make_tree_internal(rects: np.ndarray, bounds: np.ndarray, state: TreeState)
                 sub_bounds = without(bounds, d)
                 subtree = _make_tree_internal(sub_rects, sub_bounds, state.drop(d))
                 return FulfilledTree(subtree, d)
-    
+
     # Check if we need to bound a dimension
     for d in range(dimensions):
         if state.descent[d] == state.bound_dimension_at:
@@ -353,7 +353,7 @@ def _make_tree_internal(rects: np.ndarray, bounds: np.ndarray, state: TreeState)
         # Diminishing returns as this parameter is dropped; this seems like reasonable trade-off
         # Wherever we split we're hardly going to achieve much, so fall out to a list
         return ListTree(rects)
-    
+
     d = best_d
     split = splits[d]
 
@@ -365,7 +365,7 @@ def _make_tree_internal(rects: np.ndarray, bounds: np.ndarray, state: TreeState)
         # We can only get here if we're splitting on classes, and there are only two classes,
         # so we can simply split at a point between the two classes.
         split_at = np.mean(split)
-    else:        
+    else:
         if False and best_classes < 3:
             # Chance there is an overlap here, so let's check and eliminate it if possible
             # L  L L LL LL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<2
+numpy
 gdal[numpy]
 requests
 pandas


### PR DESCRIPTION
This was pinned as it helped with older versions of GDAL, but with GDAL 3.10 it's not required.